### PR TITLE
Replace Createapi view with generic view on Login

### DIFF
--- a/app/accounts/views.py
+++ b/app/accounts/views.py
@@ -40,7 +40,7 @@ class RegistrationView(generics.CreateAPIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class LoginView(generics.CreateAPIView):
+class LoginView(generics.GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (JSONRenderer,)
     serializer_class = LoginSerializer


### PR DESCRIPTION
During login at the moment, we use CreateApiView generic view to get the post effect but we never call save on the serializer which means we can just use the generic base class for efficiency